### PR TITLE
Update config_options type to str as part of mkdocs deprecating Python 2

### DIFF
--- a/mkdocs_awesome_pages_plugin/plugin.py
+++ b/mkdocs_awesome_pages_plugin/plugin.py
@@ -1,4 +1,3 @@
-from mkdocs import utils as mkdocs_utils
 from mkdocs.config import config_options, Config
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import Files
@@ -13,7 +12,7 @@ class AwesomePagesPlugin(BasePlugin):
     DEFAULT_META_FILENAME = '.pages'
 
     config_scheme = (
-        ('filename', config_options.Type(mkdocs_utils.string_types, default=DEFAULT_META_FILENAME)),
+        ('filename', config_options.Type(str, default=DEFAULT_META_FILENAME)),
         ('collapse_single_pages', config_options.Type(bool, default=False)),
         ('strict', config_options.Type(bool, default=True))
     )


### PR DESCRIPTION
mkdocs has dropped support for Python 2 as part of their 1.1 release. Change type to `str` instead of `mkdocs_utils.string_types` 