### PR TITLE
Change collections import to collections.abc

### DIFF
--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import re
 from enum import Enum
 from pathlib import PurePath
@@ -75,7 +75,7 @@ class MetaNavRestItem(MetaNavItem):
         return isinstance(item, str) and (item == '...' or re.search(MetaNavRestItem._REGEX, item))
 
 
-class RestItemList(collections.Iterable):
+class RestItemList(collections.abc.Iterable):
     def __init__(self):
         self.patterns = []
         self.all = None


### PR DESCRIPTION
Fix for no Iterable in Collections since Python 3.10 removed the backward compatibility. Collections.abc available since 3.3 so no fallback needed (this plugin targets 3.5+)

No movement on #47 for a week so here is the fix. Would love to use this plugin in CI but need it to be updated.