### PR TITLE
Allow creation of new (virtual) section from .pages

### DIFF
--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -14,7 +14,7 @@ class DuplicateRestItemError(Exception):
 
 
 class MetaNavItem:
-    def __init__(self, value: str, title: Optional[str] = None):
+    def __init__(self, value: Union[str, List["MetaNavItem"]], title: Optional[str] = None):
         self.value = value
         self.title = title
 

--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -34,8 +34,11 @@ class MetaNavItem:
 
         if isinstance(item, dict) and len(item) == 1:
             (title, value) = list(item.items())[0]
-            if isinstance(value, str) and isinstance(title, str):
-                return MetaNavItem(value, title)
+            if isinstance(title, str):
+                if isinstance(value, str):
+                    return MetaNavItem(value, title)
+                elif isinstance(value, list):
+                    return MetaNavItem([MetaNavItem.from_yaml(it, context) for it in value], title)
 
         raise TypeError("Invalid nav item format {type} [{context}]".format(type=item, context=context))
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -100,7 +100,7 @@ class AwesomeNavigation:
                     rest_items.append(meta_item)
                     result.append(meta_item)
 
-                elif isinstance(meta_item.value, (list, tuple)):
+                elif isinstance(meta_item.value, list):
                     result.append(VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value)))
 
                 elif meta_item.value in items_by_basename:

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -11,7 +11,7 @@ from mkdocs.structure.nav import (
 )
 from mkdocs.structure.pages import Page
 
-from .meta import Meta, MetaNavRestItem, RestItemList
+from .meta import Meta, MetaNavItem, MetaNavRestItem, RestItemList
 from .options import Options
 from .utils import dirname, basename, join_paths
 
@@ -93,7 +93,7 @@ class AwesomeNavigation:
         used_items = []
         rest_items = RestItemList()
 
-        def _make_nav_rec(meta_nav):
+        def _make_nav_rec(meta_nav: List[MetaNavItem]) -> List[Union[NavigationItem, MetaNavRestItem]]:
             result = []
             for meta_item in meta_nav:
                 if isinstance(meta_item, MetaNavRestItem):
@@ -134,7 +134,7 @@ class AwesomeNavigation:
                             rest[rest_item].append(item)
                             break
 
-            def _expand_rest_rec(result):
+            def _expand_rest_rec(result: List[Union[NavigationItem, MetaNavRestItem]]):
                 for index, item in enumerate(result):
                     if isinstance(item, MetaNavRestItem):
                         result[index : index + 1] = rest[item]

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -37,7 +37,7 @@ class HideInRootHasNoEffect(Warning):
         )
 
 
-class VSection(Section):
+class VirtualSection(Section):
     pass
 
 
@@ -69,7 +69,7 @@ class AwesomeNavigation:
         result = []
 
         for item in children:
-            if isinstance(item, Section) and not isinstance(item, VSection):
+            if isinstance(item, Section) and not isinstance(item, VirtualSection):
                 item = self._process_section(item, collapse)
                 if item is None:
                     continue
@@ -101,7 +101,7 @@ class AwesomeNavigation:
                     result.append(meta_item)
 
                 elif isinstance(meta_item.value, (list, tuple)):
-                    result.append(VSection(meta_item.title, children=_make_nav_rec(meta_item.value)))
+                    result.append(VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value)))
 
                 elif meta_item.value in items_by_basename:
                     item = items_by_basename[meta_item.value]

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_nav.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_nav.py
@@ -423,3 +423,49 @@ class TestNav(E2ETestCase):
     def test_not_found_not_strict(self):
         with self.assertWarns(NavEntryNotFound):
             self.mkdocs(self.createConfig(strict=False), [self.pagesFile(nav=["1.md", "..."])])
+
+    def test_vsection(self):
+        navigation = self.mkdocs(
+            self.config,
+            [
+                "a.md",
+                "b.md",
+                (
+                    "x",
+                    [
+                        "1a.md",
+                        "1b.md",
+                        "2a.md",
+                        "2b.md",
+                        "3.md",
+                        "4.md",
+                        self.pagesFile(
+                            nav=[
+                                "4.md",
+                                {"BB": ["... | *b.md"]},
+                                "...",
+                                {"AA": ["... | *a.md"]},
+                            ]
+                        ),
+                    ],
+                ),
+                self.pagesFile(nav=["...", "b.md"]),
+            ],
+        )
+
+        self.assertEqual(
+            navigation,
+            [
+                ("A", "/a"),
+                (
+                    "X",
+                    [
+                        ("4", "/x/4"),
+                        ("BB", [("1b", "/x/1b"), ("2b", "/x/2b")]),
+                        ("3", "/x/3"),
+                        ("AA", [("1a", "/x/1a"), ("2a", "/x/2a")]),
+                    ],
+                ),
+                ("B", "/b"),
+            ],
+        )

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_nav.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_nav.py
@@ -424,7 +424,7 @@ class TestNav(E2ETestCase):
         with self.assertWarns(NavEntryNotFound):
             self.mkdocs(self.createConfig(strict=False), [self.pagesFile(nav=["1.md", "..."])])
 
-    def test_vsection(self):
+    def test_virtual_section(self):
         navigation = self.mkdocs(
             self.config,
             [

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_nav.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_nav.py
@@ -388,3 +388,39 @@ class TestNav(NavigationTestCase):
                 ],
                 strict=False,
             )
+
+    def test_vsection(self):
+        navigation = self.createAwesomeNavigation(
+            [
+                self.page("1"),
+                self.page("2a"),
+                self.page("2b"),
+                self.page("2c"),
+                self.page("3a"),
+                self.page("3b"),
+                self.page("3c"),
+                self.page("4"),
+                Meta(
+                    nav=[
+                        MetaNavItem("4.md"),
+                        MetaNavItem([MetaNavItem("2a.md"), MetaNavItem("3a.md")], "AA"),
+                        MetaNavRestItem("..."),
+                        MetaNavItem([MetaNavItem("2b.md"), MetaNavItem("3b.md")], "BB"),
+                        MetaNavItem("1.md"),
+                    ]
+                ),
+            ]
+        )
+
+        self.assertNavigationEqual(
+            navigation.items,
+            [
+                self.page("4"),
+                self.section("AA", [self.page("2a"), self.page("3a")]),
+                self.page("2c"),
+                self.page("3c"),
+                self.section("BB", [self.page("2b"), self.page("3b")]),
+                self.page("1"),
+            ],
+        )
+        self.assertValidNavigation(navigation.to_mkdocs())

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_nav.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_nav.py
@@ -389,7 +389,7 @@ class TestNav(NavigationTestCase):
                 strict=False,
             )
 
-    def test_vsection(self):
+    def test_virtual_section(self):
         navigation = self.createAwesomeNavigation(
             [
                 self.page("1"),


### PR DESCRIPTION
Allows the `nav` config of `.pages` to create new sections to organize
pages.

Fixes #37