### PR TITLE
Report module version within Python

### DIFF
--- a/mkdocs_awesome_pages_plugin/__init__.py
+++ b/mkdocs_awesome_pages_plugin/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
The module version is set in pyproject.toml, but cannot be accessed from within Python. This would be helpful for internal application reporting. A trivial use-case would be adding this value to a page footer.

This PR makes the version string accessible, for example:

```
import mkdocs-awesome-pages-plugin
print(mkdocs-awesome-pages-plugin.__version__)
```

In unusual, non-packaged environments, the version will be reported as "unknown".
