### PR TITLE
Fix handling of custom section titles

### DIFF
--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_order_and_sort.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_order_and_sort.py
@@ -424,3 +424,19 @@ class TestOrderAndSort(E2ETestCase):
             navigation,
             [("A", "/3"), ("B", [("C", "/B/1"), ("B", "/B/2")]), ("C", "/1")],
         )
+
+    def test_order_by_title_section_with_custom_title(self):
+        navigation = self.mkdocs(
+            self.createConfig(),
+            [
+                ("1.md", "# C"),
+                ("B", [("1.md", "# C"), ("2.md", "# B"), self.pagesFile(title="D")]),
+                ("3.md", "# A"),
+                self.pagesFile(order_by="title"),
+            ],
+        )
+
+        self.assertEqual(
+            navigation,
+            [("A", "/3"), ("C", "/1"), ("D", [("C", "/B/1"), ("B", "/B/2")])],
+        )


### PR DESCRIPTION
Fixes #73
To handle custom titles for sections the `get_title` function required access to the `AwesomeNavigation.meta.sections` structure to access meta properties of a given section item. One option was to pass the `self` reference as a parameter, but there was no such case in the code base. Therefore, I decided to transform the function into a class method to keep the current style. ✌️ 
I'm assuming no additional tests are needed. 