### PR TITLE
Handle plugin generated content and config

### DIFF
--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -2,13 +2,11 @@ import collections.abc
 import re
 from enum import Enum
 from pathlib import PurePath
-from typing import Optional, List, Union, Any, Iterator, TYPE_CHECKING
+from typing import Optional, List, Union, Any, Iterator
 
+from mkdocs.structure.files import Files
 import yaml
 from wcmatch import glob
-
-if TYPE_CHECKING:
-    from mkdocs.structure.files import Files
 
 
 class DuplicateRestItemError(Exception):

--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -2,10 +2,13 @@ import collections.abc
 import re
 from enum import Enum
 from pathlib import PurePath
-from typing import Optional, List, Union, Any, Iterator
+from typing import Optional, List, Union, Any, Iterator, TYPE_CHECKING
 
 import yaml
 from wcmatch import glob
+
+if TYPE_CHECKING:
+    from mkdocs.structure.files import Files
 
 
 class DuplicateRestItemError(Exception):
@@ -147,13 +150,20 @@ class Meta:
         self.order_by = order_by
 
     @staticmethod
-    def try_load_from(path: Optional[str]) -> "Meta":
-        if path is None:
+    def try_load_from_files(rel_path: Optional[str], files: "Files") -> "Meta":
+        if rel_path is None:
             return Meta()
+
+        file = files.src_paths.get(rel_path)
+        if file is None:
+            return Meta(path=rel_path)
+
         try:
-            return Meta.load_from(path)
+            meta = Meta.load_from(file.abs_src_path)
+            meta.path = file.src_path  # Use the relative path
+            return meta
         except FileNotFoundError:
-            return Meta(path=path)
+            return Meta(path=file.src_path)
 
     @staticmethod
     def load_from(path: str) -> "Meta":

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -280,8 +280,7 @@ class NavigationMeta:
         paths: List[str] = []
         for item in items:
             if isinstance(item, Page):
-                if Path(self.docs_dir) in Path(item.file.abs_src_path).parents:
-                    paths.append(item.file.src_path)
+                paths.append(item.file.src_path)
             elif isinstance(item, Section):
                 section_meta = self._gather_metadata(item.children)
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -26,20 +26,26 @@ NavigationItem = Union[Page, Section, Link]
 
 class NavEntryNotFound(Warning):
     def __init__(self, entry: str, context: str):
-        super().__init__('Nav entry "{entry}" not found. [{context}]'.format(entry=entry, context=context))
+        super().__init__(
+            'Nav entry "{entry}" not found. [{context}]'.format(entry=entry, context=context)
+        )
 
 
 class TitleInRootHasNoEffect(Warning):
     def __init__(self, filename: str):
         super().__init__(
-            'Using the "title" attribute in the {filename} file of the doc root has no effect'.format(filename=filename)
+            'Using the "title" attribute in the {filename} file of the doc root has no effect'.format(
+                filename=filename
+            )
         )
 
 
 class HideInRootHasNoEffect(Warning):
     def __init__(self, filename: str):
         super().__init__(
-            'Using the "hide" attribute in the {filename} file of the doc root has no effect'.format(filename=filename)
+            'Using the "hide" attribute in the {filename} file of the doc root has no effect'.format(
+                filename=filename
+            )
         )
 
 
@@ -66,9 +72,13 @@ class AwesomeNavigation:
         if self.meta.root.hide is not None:
             warnings.warn(HideInRootHasNoEffect(self.options.filename))
 
-        self.items = self._process_children(items, self.options.collapse_single_pages, self.meta.root)
+        self.items = self._process_children(
+            items, self.options.collapse_single_pages, self.meta.root
+        )
 
-    def _process_children(self, children: List[NavigationItem], collapse: bool, meta: Meta) -> List[NavigationItem]:
+    def _process_children(
+        self, children: List[NavigationItem], collapse: bool, meta: Meta
+    ) -> List[NavigationItem]:
         self._order(children, meta)
         children = self._nav(children, meta)
         return self._process_child_sections(children, collapse)
@@ -127,7 +137,9 @@ class AwesomeNavigation:
                     result.append(meta_item)
 
                 elif isinstance(meta_item.value, list):
-                    result.append(VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value)))
+                    result.append(
+                        VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value))
+                    )
 
                 elif meta_item.value in items_by_basename:
                     item = items_by_basename[meta_item.value]
@@ -172,7 +184,9 @@ class AwesomeNavigation:
 
         return result
 
-    def _process_section(self, section: Section, collapse_recursive: bool) -> Optional[NavigationItem]:
+    def _process_section(
+        self, section: Section, collapse_recursive: bool
+    ) -> Optional[NavigationItem]:
         meta = self.meta.sections[section]
 
         if meta.hide is True:
@@ -195,8 +209,6 @@ class AwesomeNavigation:
 
     def _get_item_path(self, item: NavigationItem) -> Optional[str]:
         if isinstance(item, Section):
-            # TODO: This is now `None` where it wasn't before!
-            #   self.meta.sections[item].path
             return dirname(self.meta.sections[item].path)
         elif isinstance(item, Page):
             return item.file.src_path
@@ -247,7 +259,9 @@ class AwesomeNavigation:
             section.title = meta.title
 
     @staticmethod
-    def _collapse(section: Section, collapse: Optional[bool], collapse_recursive: bool) -> NavigationItem:
+    def _collapse(
+        section: Section, collapse: Optional[bool], collapse_recursive: bool
+    ) -> NavigationItem:
         if collapse is None:
             collapse = collapse_recursive
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -26,26 +26,20 @@ NavigationItem = Union[Page, Section, Link]
 
 class NavEntryNotFound(Warning):
     def __init__(self, entry: str, context: str):
-        super().__init__(
-            'Nav entry "{entry}" not found. [{context}]'.format(entry=entry, context=context)
-        )
+        super().__init__('Nav entry "{entry}" not found. [{context}]'.format(entry=entry, context=context))
 
 
 class TitleInRootHasNoEffect(Warning):
     def __init__(self, filename: str):
         super().__init__(
-            'Using the "title" attribute in the {filename} file of the doc root has no effect'.format(
-                filename=filename
-            )
+            'Using the "title" attribute in the {filename} file of the doc root has no effect'.format(filename=filename)
         )
 
 
 class HideInRootHasNoEffect(Warning):
     def __init__(self, filename: str):
         super().__init__(
-            'Using the "hide" attribute in the {filename} file of the doc root has no effect'.format(
-                filename=filename
-            )
+            'Using the "hide" attribute in the {filename} file of the doc root has no effect'.format(filename=filename)
         )
 
 
@@ -72,13 +66,9 @@ class AwesomeNavigation:
         if self.meta.root.hide is not None:
             warnings.warn(HideInRootHasNoEffect(self.options.filename))
 
-        self.items = self._process_children(
-            items, self.options.collapse_single_pages, self.meta.root
-        )
+        self.items = self._process_children(items, self.options.collapse_single_pages, self.meta.root)
 
-    def _process_children(
-        self, children: List[NavigationItem], collapse: bool, meta: Meta
-    ) -> List[NavigationItem]:
+    def _process_children(self, children: List[NavigationItem], collapse: bool, meta: Meta) -> List[NavigationItem]:
         self._order(children, meta)
         children = self._nav(children, meta)
         return self._process_child_sections(children, collapse)
@@ -127,9 +117,7 @@ class AwesomeNavigation:
         used_items = []
         rest_items = RestItemList()
 
-        def _make_nav_rec(
-            meta_nav: List[MetaNavItem],
-        ) -> List[Union[NavigationItem, MetaNavRestItem]]:
+        def _make_nav_rec(meta_nav: List[MetaNavItem]) -> List[Union[NavigationItem, MetaNavRestItem]]:
             result = []
             for meta_item in meta_nav:
                 if isinstance(meta_item, MetaNavRestItem):
@@ -137,9 +125,7 @@ class AwesomeNavigation:
                     result.append(meta_item)
 
                 elif isinstance(meta_item.value, list):
-                    result.append(
-                        VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value))
-                    )
+                    result.append(VirtualSection(meta_item.title, children=_make_nav_rec(meta_item.value)))
 
                 elif meta_item.value in items_by_basename:
                     item = items_by_basename[meta_item.value]
@@ -184,9 +170,7 @@ class AwesomeNavigation:
 
         return result
 
-    def _process_section(
-        self, section: Section, collapse_recursive: bool
-    ) -> Optional[NavigationItem]:
+    def _process_section(self, section: Section, collapse_recursive: bool) -> Optional[NavigationItem]:
         meta = self.meta.sections[section]
 
         if meta.hide is True:
@@ -259,9 +243,7 @@ class AwesomeNavigation:
             section.title = meta.title
 
     @staticmethod
-    def _collapse(
-        section: Section, collapse: Optional[bool], collapse_recursive: bool
-    ) -> NavigationItem:
+    def _collapse(section: Section, collapse: Optional[bool], collapse_recursive: bool) -> NavigationItem:
         if collapse is None:
             collapse = collapse_recursive
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -296,8 +296,11 @@ class NavigationMeta:
 
         common_dirname = self._common_dirname(paths) or ""
         config_path = os.path.join(common_dirname, self.options.filename)
-        maybe_config_file = self.files.src_paths.get(config_path, None)
-        return Meta.try_load_from(getattr(maybe_config_file, "abs_src_path", None))
+        if config_path in self.files.src_paths:
+            config_path = self.files.src_paths[config_path].abs_src_path
+        else:
+            config_path = os.path.join(self.docs_dir, config_path)
+        return Meta.try_load_from(config_path)
 
     @staticmethod
     def _common_dirname(paths: List[str]) -> Optional[str]:

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -1,5 +1,3 @@
-import os.path
-from pathlib import Path
 import warnings
 
 import mkdocs.utils
@@ -277,8 +275,7 @@ class NavigationMeta:
         paths: List[str] = []
         for item in items:
             if isinstance(item, Page):
-                if item.file.src_path in self.files.src_paths:
-                    paths.append(item.file.src_path)
+                paths.append(item.file.src_path)
             elif isinstance(item, Section):
                 section_meta = self._gather_metadata(item.children)
 

--- a/mkdocs_awesome_pages_plugin/plugin.py
+++ b/mkdocs_awesome_pages_plugin/plugin.py
@@ -1,3 +1,4 @@
+import os.path
 import warnings
 from typing import List, Dict
 
@@ -61,7 +62,7 @@ class AwesomePagesPlugin(BasePlugin):
             nav = explicit_nav
 
         return AwesomeNavigation(
-            nav.items, Options(**self.config), config["docs_dir"], files, explicit_sections
+            nav.items, Options(**self.config), os.path.relpath(config["docs_dir"]), files, explicit_sections
         ).to_mkdocs()
 
     def on_config(self, config: Config):

--- a/mkdocs_awesome_pages_plugin/plugin.py
+++ b/mkdocs_awesome_pages_plugin/plugin.py
@@ -50,14 +50,17 @@ class AwesomePagesPlugin(BasePlugin):
     def on_files(self, files: Files, config: Config):
         # Add config files to Files, so we can unconditionally load files/configs from Files
         config_files = glob.glob(os.path.join(config["docs_dir"], f"**/{self.config['filename']}"), recursive=True)
+        initial_src_paths = files.src_paths
         for filename in config_files:
-            file = File(
-                os.path.relpath(filename, config["docs_dir"]),
-                src_dir=config["docs_dir"],
-                dest_dir=config["site_dir"],
-                use_directory_urls=config["use_directory_urls"],
-            )
-            files.append(file)
+            config_path = os.path.relpath(filename, config["docs_dir"])
+            if config_path not in initial_src_paths:
+                file = File(
+                    os.path.relpath(filename, config["docs_dir"]),
+                    src_dir=config["docs_dir"],
+                    dest_dir=config["site_dir"],
+                    use_directory_urls=config["use_directory_urls"],
+                )
+                files.append(file)
         return files
 
     def on_nav(self, nav: MkDocsNavigation, config: Config, files: Files):

--- a/mkdocs_awesome_pages_plugin/plugin.py
+++ b/mkdocs_awesome_pages_plugin/plugin.py
@@ -60,7 +60,9 @@ class AwesomePagesPlugin(BasePlugin):
             self._insert_rest(explicit_nav.items)
             nav = explicit_nav
 
-        return AwesomeNavigation(nav.items, Options(**self.config), config["docs_dir"], explicit_sections).to_mkdocs()
+        return AwesomeNavigation(
+            nav.items, Options(**self.config), config["docs_dir"], files, explicit_sections
+        ).to_mkdocs()
 
     def on_config(self, config: Config):
         for name, plugin in config["plugins"].items():

--- a/mkdocs_awesome_pages_plugin/tests/e2e/base.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/base.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import warnings
-from typing import Iterable, Optional, List, Tuple, Union, Dict
+from typing import Iterable, Optional, List, Tuple, Union, Dict, TypeVar
 from unittest import TestCase
 
 import yaml
@@ -13,10 +13,13 @@ from mkdocs.config import load_config
 
 from ...utils import cd
 
+PluginBaseT = TypeVar("PluginBaseT", bound=plugins.BasePlugin)
+
 
 class E2ETestCase(TestCase):
     MIN_ROOT_ITEMS = 2
     DUMMY_NAME = "__dummy__"
+    PLUGINS: Tuple[PluginBaseT] = ()
 
     def setUp(self):
         self.config = self.createConfig()
@@ -176,8 +179,7 @@ class E2ETestCase(TestCase):
         def _patched_get_plugins():
             result = _original_get_plugins()
 
-            class_plugins = getattr(cls, "PLUGINS", [])
-            for class_plugin in class_plugins:
+            for class_plugin in cls.PLUGINS:
                 name = class_plugin.__name__.lower()
                 result[name] = EntryPoint(
                     name=name,

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -1,3 +1,4 @@
+import os.path
 import tempfile
 from pathlib import Path
 
@@ -32,7 +33,7 @@ class GeneratedFiles(BasePlugin):
                 if entry.is_file():
                     files.append(
                         File(
-                            f"{path.relative_to(docs_dir)}/{entry.name}",
+                            os.path.join(path.relative_to(docs_dir), entry.name),
                             src_dir=self.src_dir.name,
                             dest_dir=config["site_dir"],
                             use_directory_urls=config["use_directory_urls"],
@@ -48,7 +49,7 @@ class GeneratedFiles(BasePlugin):
 class TestGeneratedFiles(E2ETestCase):
     """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
 
-    PLUGINS = [GeneratedFiles]
+    PLUGINS = (GeneratedFiles,)
 
     def test_mixed(self):
         navigation = self.mkdocs(

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -15,8 +15,6 @@ class GeneratedFiles(BasePlugin):
     def on_post_build(self, *args, **kwargs):
         self.src_dir.cleanup()
 
-
-
     def on_files(self, files, config):
         docs_dir = Path(self.src_dir.name)
         section_dir = docs_dir / "section"
@@ -45,19 +43,6 @@ class GeneratedFiles(BasePlugin):
         write_files(section_dir)
         return files
 
-    @staticmethod
-    def _write_files(path, files, config):
-        for file in path.iterdir():
-            if file.is_file():
-                files.append(
-                    File(
-                        f"section/{file.name}",
-                        src_dir=self.src_dir.name,
-                        dest_dir=config["site_dir"],
-                        use_directory_urls=config["use_directory_urls"],
-                    )
-                )
-
 
 class TestGeneratedFiles(E2ETestCase):
     PLUGINS = [GeneratedFiles]
@@ -78,7 +63,12 @@ class TestGeneratedFiles(E2ETestCase):
             [
                 (
                     "Section",
-                    [("3", "/section/3"), ("1", "/section/1"), ("2", "/section/2")],
+                    [
+                        ("3", "/section/3"),
+                        ("Sub", [("A", "/section/sub/a")]),
+                        ("1", "/section/1"),
+                        ("2", "/section/2"),
+                    ],
                 )
             ],
         )
@@ -94,8 +84,7 @@ class TestGeneratedFiles(E2ETestCase):
             [
                 (
                     "Section",
-                    [("3", "/section/3"), ("2", "/section/2")],
+                    [("3", "/section/3"), ("Sub", [("A", "/section/sub/a")]), ("2", "/section/2")],
                 )
             ],
         )
-

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -21,10 +21,11 @@ class GeneratedFiles(BasePlugin):
         section_dir.mkdir()
         (section_dir / "2.md").touch()
         (section_dir / "3.md").touch()
+        (section_dir / ".pages").write_text(yaml.dump({"arrange": ["3.md", "sub", "..."]}))
         subsection_dir = section_dir / "sub"
         subsection_dir.mkdir()
         (subsection_dir / "a.md").touch()
-        (section_dir / ".pages").write_text(yaml.dump({"arrange": ["3.md", "sub", "..."]}))
+        (subsection_dir / ".pages").write_text(yaml.dump({"nav": ["a.md"]}))
 
         def write_files(path):
             for entry in path.iterdir():

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -45,10 +45,11 @@ class GeneratedFiles(BasePlugin):
 
 
 class TestGeneratedFiles(E2ETestCase):
+    """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
+
     PLUGINS = [GeneratedFiles]
 
     def test_mixed(self):
-        """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
         navigation = self.mkdocs(
             self.config,
             [
@@ -74,7 +75,6 @@ class TestGeneratedFiles(E2ETestCase):
         )
 
     def test_all_virtual(self):
-        """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
         navigation = self.mkdocs(
             self.config,
             [],

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -1,0 +1,60 @@
+import tempfile
+from pathlib import Path
+
+import yaml
+from mkdocs.plugins import BasePlugin
+from mkdocs.structure.files import File
+
+from .base import E2ETestCase
+
+
+class GeneratedFiles(BasePlugin):
+    def on_pre_build(self, *args, **kwargs):
+        self.src_dir = tempfile.TemporaryDirectory()
+
+    def on_post_build(self, *args, **kwargs):
+        self.src_dir.cleanup()
+
+    def on_files(self, files, config):
+        docs_dir = Path(self.src_dir.name)
+        section_dir = docs_dir / "section"
+        section_dir.mkdir()
+        (section_dir / "2.md").touch()
+        (section_dir / "3.md").touch()
+        (section_dir / ".pages").write_text(yaml.dump({"arrange": ["2.md", "...", "1.md"]}))
+
+        for file in section_dir.iterdir():
+            files.append(
+                File(
+                    f"section/{file.name}",
+                    src_dir=self.src_dir.name,
+                    dest_dir=config["site_dir"],
+                    use_directory_urls=config["use_directory_urls"],
+                )
+            )
+        return files
+
+
+class TestGeneratedFiles(E2ETestCase):
+    PLUGINS = [GeneratedFiles]
+
+    def test_issue78(self):
+        """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
+        navigation = self.mkdocs(
+            self.config,
+            [
+                (
+                    "section",
+                    ["1.md"],
+                )
+            ],
+        )
+        self.assertEqual(
+            navigation,
+            [
+                (
+                    "Section",
+                    [("2", "/section/2"), ("3", "/section/3"), ("1", "/section/1")],
+                )
+            ],
+        )

--- a/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
+++ b/mkdocs_awesome_pages_plugin/tests/e2e/test_gen_files.py
@@ -15,30 +15,54 @@ class GeneratedFiles(BasePlugin):
     def on_post_build(self, *args, **kwargs):
         self.src_dir.cleanup()
 
+
+
     def on_files(self, files, config):
         docs_dir = Path(self.src_dir.name)
         section_dir = docs_dir / "section"
         section_dir.mkdir()
         (section_dir / "2.md").touch()
         (section_dir / "3.md").touch()
-        (section_dir / ".pages").write_text(yaml.dump({"arrange": ["2.md", "...", "1.md"]}))
+        subsection_dir = section_dir / "sub"
+        subsection_dir.mkdir()
+        (subsection_dir / "a.md").touch()
+        (section_dir / ".pages").write_text(yaml.dump({"arrange": ["3.md", "sub", "..."]}))
 
-        for file in section_dir.iterdir():
-            files.append(
-                File(
-                    f"section/{file.name}",
-                    src_dir=self.src_dir.name,
-                    dest_dir=config["site_dir"],
-                    use_directory_urls=config["use_directory_urls"],
-                )
-            )
+        def write_files(path):
+            for entry in path.iterdir():
+                if entry.is_file():
+                    files.append(
+                        File(
+                            f"{path.relative_to(docs_dir)}/{entry.name}",
+                            src_dir=self.src_dir.name,
+                            dest_dir=config["site_dir"],
+                            use_directory_urls=config["use_directory_urls"],
+                        )
+                    )
+                else:
+                    write_files(path / entry.name)
+
+        write_files(section_dir)
         return files
+
+    @staticmethod
+    def _write_files(path, files, config):
+        for file in path.iterdir():
+            if file.is_file():
+                files.append(
+                    File(
+                        f"section/{file.name}",
+                        src_dir=self.src_dir.name,
+                        dest_dir=config["site_dir"],
+                        use_directory_urls=config["use_directory_urls"],
+                    )
+                )
 
 
 class TestGeneratedFiles(E2ETestCase):
     PLUGINS = [GeneratedFiles]
 
-    def test_issue78(self):
+    def test_mixed(self):
         """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
         navigation = self.mkdocs(
             self.config,
@@ -54,7 +78,24 @@ class TestGeneratedFiles(E2ETestCase):
             [
                 (
                     "Section",
-                    [("2", "/section/2"), ("3", "/section/3"), ("1", "/section/1")],
+                    [("3", "/section/3"), ("1", "/section/1"), ("2", "/section/2")],
                 )
             ],
         )
+
+    def test_all_virtual(self):
+        """See https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin/issues/78."""
+        navigation = self.mkdocs(
+            self.config,
+            [],
+        )
+        self.assertEqual(
+            navigation,
+            [
+                (
+                    "Section",
+                    [("3", "/section/3"), ("2", "/section/2")],
+                )
+            ],
+        )
+

--- a/mkdocs_awesome_pages_plugin/tests/navigation/base.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/base.py
@@ -75,7 +75,6 @@ class NavigationTestCase(TestCase):
                 collapse_single_pages=collapse_single_pages,
                 strict=strict,
             ),
-            docs_dir="",
             files=Files([]),
             explicit_sections=set(),
         )

--- a/mkdocs_awesome_pages_plugin/tests/navigation/base.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/base.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Union, Optional
 from unittest import TestCase, mock
 
-from mkdocs.structure.files import File
+from mkdocs.structure.files import File, Files
 from mkdocs.structure.nav import (
     Navigation as MkDocsNavigation,
     Section,
@@ -76,6 +76,7 @@ class NavigationTestCase(TestCase):
                 strict=strict,
             ),
             docs_dir="",
+            files=Files([]),
             explicit_sections=set(),
         )
 

--- a/mkdocs_awesome_pages_plugin/tests/navigation/base.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/base.py
@@ -1,4 +1,4 @@
-import os
+import os.path
 from typing import List, Union, Optional
 from unittest import TestCase, mock
 
@@ -25,8 +25,8 @@ class NavigationMetaMock:
 
 class NavigationTestCase(TestCase):
     @staticmethod
-    def page(title: str, path: Optional[str] = None, docs_dir: str = "") -> Page:
-        return Page(title, File(path or title + ".md", docs_dir, "", False), {})
+    def page(title: str, path: Optional[str] = None) -> Page:
+        return Page(title, File(path or title + ".md", os.path.abspath("docs"), "", False), {})
 
     @staticmethod
     def link(title: str, url: Optional[str] = None):

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from unittest import TestCase
 
+from mkdocs.structure.files import Files
+
 from .base import NavigationTestCase
 from ...meta import Meta, MetaNavRestItem, RestType
 from ...navigation import NavigationMeta
@@ -31,7 +33,7 @@ class TestCommonDirname(TestCase):
 class TestMeta(NavigationTestCase):
     def assertMeta(self, actual: Meta, expected: Optional[Meta] = None, *, path: Optional[str] = None):
         if expected is None:
-            expected = Meta(path=path)
+            expected = Meta(path=path or ".pages")
 
         self.assertEqual(actual.collapse_single_pages, expected.collapse_single_pages)
         self.assertEqual(actual.collapse, expected.collapse)
@@ -46,7 +48,7 @@ class TestMeta(NavigationTestCase):
         self.options = Options(filename=".pages", collapse_single_pages=False, strict=True)
 
     def test_empty(self):
-        meta = NavigationMeta([], self.options, docs_dir="", explicit_sections=set())
+        meta = NavigationMeta([], self.options, docs_dir="", files=Files([]), explicit_sections=set())
 
         self.assertEqual(len(meta.sections), 0)
         self.assertEmptyMeta(meta.root)
@@ -56,6 +58,7 @@ class TestMeta(NavigationTestCase):
             [self.page("Page", "page.md")],
             self.options,
             docs_dir="",
+            files=Files([]),
             explicit_sections=set(),
         )
 
@@ -64,7 +67,7 @@ class TestMeta(NavigationTestCase):
 
     def test_empty_section(self):
         section = self.section("Section", [])
-        meta = NavigationMeta([section], self.options, docs_dir="", explicit_sections=set())
+        meta = NavigationMeta([section], self.options, docs_dir="", files=Files([]), explicit_sections=set())
 
         self.assertEqual(len(meta.sections), 1)
         self.assertEmptyMeta(meta.sections[section])
@@ -72,7 +75,7 @@ class TestMeta(NavigationTestCase):
 
     def test_section(self):
         section = self.section("Section", [self.page("Page", "section/page.md")])
-        meta = NavigationMeta([section], self.options, docs_dir="", explicit_sections=set())
+        meta = NavigationMeta([section], self.options, docs_dir="", files=Files([]), explicit_sections=set())
 
         self.assertEqual(len(meta.sections), 1)
         self.assertMeta(meta.sections[section], path="section/.pages")
@@ -86,7 +89,7 @@ class TestMeta(NavigationTestCase):
         e = self.section("E", [self.page("2", "c/e/2.md")])
         c = self.section("C", [d, e])
 
-        meta = NavigationMeta([a, c], self.options, docs_dir="", explicit_sections=set())
+        meta = NavigationMeta([a, c], self.options, docs_dir="", files=Files([]), explicit_sections=set())
 
         self.assertEqual(len(meta.sections), 5)
 
@@ -105,6 +108,7 @@ class TestMeta(NavigationTestCase):
             [section],
             Options(filename=".index", collapse_single_pages=False, strict=True),
             docs_dir="",
+            files=Files([]),
             explicit_sections=set(),
         )
 
@@ -117,6 +121,7 @@ class TestMeta(NavigationTestCase):
             [self.page("Page", "page.md"), self.link("Link")],
             self.options,
             docs_dir="",
+            files=Files([]),
             explicit_sections=set(),
         )
 
@@ -125,7 +130,7 @@ class TestMeta(NavigationTestCase):
 
     def test_no_common_dirname(self):
         section = self.section("Section", [self.page("1", "a/1.md"), self.page("2", "b/2.md")])
-        meta = NavigationMeta([section], self.options, docs_dir="", explicit_sections=set())
+        meta = NavigationMeta([section], self.options, docs_dir="", files=Files([]), explicit_sections=set())
 
         self.assertEqual(len(meta.sections), 1)
         self.assertEmptyMeta(meta.sections[section])
@@ -139,6 +144,7 @@ class TestMeta(NavigationTestCase):
             ],
             self.options,
             docs_dir="/docs",
+            files=Files([]),
             explicit_sections=set(),
         )
 

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
@@ -61,11 +61,11 @@ class TestMeta(NavigationTestCase):
 
         def populate_config_dirs(items: List[NavigationItem]):
             for item in items:
-                if isinstance(item, Page) and not item.url.startswith("/"):
+                if isinstance(item, Page):
                     config_dirs.add(
                         (
                             os.path.dirname(item.file.src_path),
-                            os.path.dirname(item.file.abs_src_path),
+                            item.file.abs_src_path[: -len(item.file.src_path)],
                         )
                     )
                     files.append(item.file)
@@ -74,11 +74,11 @@ class TestMeta(NavigationTestCase):
 
         populate_config_dirs(items)
 
-        for rel_path, abs_path in config_dirs:
+        for rel_config_dir, abs_docs_dir in config_dirs:
             files.append(
                 File(
-                    os.path.join(rel_path, options.filename),
-                    src_dir=abs_path,
+                    os.path.join(rel_config_dir, options.filename),
+                    src_dir=abs_docs_dir,
                     dest_dir="",
                     use_directory_urls=False,
                 )

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
@@ -33,7 +33,7 @@ class TestCommonDirname(TestCase):
 class TestMeta(NavigationTestCase):
     def assertMeta(self, actual: Meta, expected: Optional[Meta] = None, *, path: Optional[str] = None):
         if expected is None:
-            expected = Meta(path=path or ".pages")
+            expected = Meta(path=path)
 
         self.assertEqual(actual.collapse_single_pages, expected.collapse_single_pages)
         self.assertEqual(actual.collapse, expected.collapse)
@@ -96,7 +96,7 @@ class TestMeta(NavigationTestCase):
         self.assertMeta(meta.sections[a], path="a/.pages")
         self.assertMeta(meta.sections[b], path="a/b/.pages")
 
-        self.assertMeta(meta.sections[c], path=".pages")
+        self.assertMeta(meta.sections[c], path="c/.pages")
         self.assertEmptyMeta(meta.sections[d])
         self.assertMeta(meta.sections[e], path="c/e/.pages")
 

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
@@ -74,11 +74,11 @@ class TestMeta(NavigationTestCase):
 
         populate_config_dirs(items)
 
-        for config_dir, docs_dir in config_dirs:
+        for rel_path, abs_path in config_dirs:
             files.append(
                 File(
-                    os.path.join(config_dir, options.filename),
-                    src_dir=docs_dir,
+                    os.path.join(rel_path, options.filename),
+                    src_dir=abs_path,
                     dest_dir="",
                     use_directory_urls=False,
                 )
@@ -159,18 +159,6 @@ class TestMeta(NavigationTestCase):
         self.assertEqual(len(meta.sections), 1)
         self.assertEmptyMeta(meta.sections[section])
         self.assertEmptyMeta(meta.root)
-
-    def test_path_outside_docs(self):
-        meta = self._make_nav_meta(
-            [
-                self.page("Page", "page.md", docs_dir="/docs"),
-                self.page("Outside", "/outside", docs_dir="/docs"),
-            ],
-            self.options,
-        )
-
-        self.assertEqual(len(meta.sections), 0)
-        self.assertMeta(meta.root, path=".pages")
 
 
 class TestRestParsing(NavigationTestCase):

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_meta.py
@@ -96,7 +96,7 @@ class TestMeta(NavigationTestCase):
         self.assertMeta(meta.sections[a], path="a/.pages")
         self.assertMeta(meta.sections[b], path="a/b/.pages")
 
-        self.assertMeta(meta.sections[c], path="c/.pages")
+        self.assertMeta(meta.sections[c], path=".pages")
         self.assertEmptyMeta(meta.sections[d])
         self.assertMeta(meta.sections[e], path="c/e/.pages")
 

--- a/mkdocs_awesome_pages_plugin/tests/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/test_meta.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase, mock
 
 from mkdocs.structure.files import File, Files
@@ -193,8 +194,9 @@ class TestLoadFrom(TestCase):
 @mock.patch("builtins.open", new_callable=FileMock)
 class TestTryLoadFrom(TestCase):
     def test_in_docs_dir(self, file_mock: FileMock):
-        file_mock["docs/.pages"].read_data = "title: Section Title\n"
-        files = Files([File(".pages", "docs", "", False)])
+        docs_path = Path("docs").resolve()
+        file_mock[str(docs_path / ".pages")].read_data = "title: Section Title\n"
+        files = Files([File(".pages", str(docs_path), "", False)])
 
         meta = Meta.try_load_from_files(".pages", files)
         self.assertEqual(meta.title, "Section Title")

--- a/mkdocs_awesome_pages_plugin/tests/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/test_meta.py
@@ -30,9 +30,7 @@ class TestLoadFrom(TestCase):
         meta = Meta.load_from(".pages")
         self.assertEqual(meta.path, ".pages")
         self.assertIsNone(meta.title)
-        self.assertEqual(
-            meta.nav, [MetaNavItem("2.md"), MetaNavItem("1.md"), MetaNavRestItem("...")]
-        )
+        self.assertEqual(meta.nav, [MetaNavItem("2.md"), MetaNavItem("1.md"), MetaNavRestItem("...")])
 
     def test_arrange_rest_token(self, file_mock: FileMock):
         file_mock[".pages"].read_data = "arrange:\n" "  - 2.md\n" "  - ...\n" "  - 1.md\n"
@@ -40,26 +38,18 @@ class TestLoadFrom(TestCase):
         meta = Meta.load_from(".pages")
         self.assertEqual(meta.path, ".pages")
         self.assertIsNone(meta.title)
-        self.assertEqual(
-            meta.nav, [MetaNavItem("2.md"), MetaNavRestItem("..."), MetaNavItem("1.md")]
-        )
+        self.assertEqual(meta.nav, [MetaNavItem("2.md"), MetaNavRestItem("..."), MetaNavItem("1.md")])
 
     def test_title_and_arrange(self, file_mock: FileMock):
-        file_mock[".pages"].read_data = (
-            "title: Section Title\n" "arrange:\n" "  - 2.md\n" "  - 1.md\n"
-        )
+        file_mock[".pages"].read_data = "title: Section Title\n" "arrange:\n" "  - 2.md\n" "  - 1.md\n"
 
         meta = Meta.load_from(".pages")
         self.assertEqual(meta.path, ".pages")
         self.assertEqual(meta.title, "Section Title")
-        self.assertEqual(
-            meta.nav, [MetaNavItem("2.md"), MetaNavItem("1.md"), MetaNavRestItem("...")]
-        )
+        self.assertEqual(meta.nav, [MetaNavItem("2.md"), MetaNavItem("1.md"), MetaNavRestItem("...")])
 
     def test_arrange_and_nav(self, file_mock: FileMock):
-        file_mock[".pages"].read_data = (
-            "arrange:\n" "  - 2.md\n" "  - 1.md\n" "nav:\n" "  - 1.md\n" "  - 2.md\n"
-        )
+        file_mock[".pages"].read_data = "arrange:\n" "  - 2.md\n" "  - 1.md\n" "nav:\n" "  - 1.md\n" "  - 2.md\n"
 
         meta = Meta.load_from(".pages")
         self.assertEqual(meta.path, ".pages")
@@ -124,9 +114,7 @@ class TestLoadFrom(TestCase):
             Meta.load_from(".pages")
 
     def test_duplicate_rest_token(self, file_mock: FileMock):
-        file_mock[".pages"].read_data = (
-            "arrange:\n" "  - 2.md\n" "  - ...\n" "  - 1.md\n" "  - ...\n"
-        )
+        file_mock[".pages"].read_data = "arrange:\n" "  - 2.md\n" "  - ...\n" "  - 1.md\n" "  - ...\n"
 
         with self.assertRaises(DuplicateRestItemError):
             Meta.load_from(".pages")
@@ -192,9 +180,7 @@ class TestLoadFrom(TestCase):
             Meta.load_from(".pages")
 
     def test_duplicate_nav_rest_pattern_glob(self, file_mock: FileMock):
-        file_mock[".pages"].read_data = (
-            "nav:\n" "  - ... | a*.md\n" "  - 1.md\n" "  - ... | a*.md\n"
-        )
+        file_mock[".pages"].read_data = "nav:\n" "  - ... | a*.md\n" "  - 1.md\n" "  - ... | a*.md\n"
 
         with self.assertRaises(DuplicateRestItemError):
             Meta.load_from(".pages")

--- a/mkdocs_awesome_pages_plugin/tests/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/test_meta.py
@@ -200,6 +200,3 @@ class TestTryLoadFrom(TestCase):
         meta = Meta.try_load_from(".pages")
         self.assertIsInstance(meta, Meta)
 
-    def test_none_path(self, file_mock: FileMock):
-        meta = Meta.try_load_from(None)
-        self.assertIsInstance(meta, Meta)

--- a/mkdocs_awesome_pages_plugin/tests/test_meta.py
+++ b/mkdocs_awesome_pages_plugin/tests/test_meta.py
@@ -193,16 +193,8 @@ class TestLoadFrom(TestCase):
 @mock.patch("builtins.open", new_callable=FileMock)
 class TestTryLoadFrom(TestCase):
     def test_in_docs_dir(self, file_mock: FileMock):
-        file_mock["/docs/.pages"].read_data = "title: Section Title\n"
-        files = Files([File(".pages", "/docs", "", False)])
-
-        meta = Meta.try_load_from_files(".pages", files)
-        self.assertEqual(meta.title, "Section Title")
-        self.assertEqual(meta.path, ".pages")
-
-    def test_generated_file(self, file_mock: FileMock):
-        file_mock["/tmp/.pages"].read_data = "title: Section Title\n"
-        files = Files([File(".pages", "/tmp", "", False)])
+        file_mock["docs/.pages"].read_data = "title: Section Title\n"
+        files = Files([File(".pages", "docs", "", False)])
 
         meta = Meta.try_load_from_files(".pages", files)
         self.assertEqual(meta.title, "Section Title")


### PR DESCRIPTION
This change allows `mkdocs-awesome-pages-plugin` to play nicely with `mkdocs-gen-files`, specifically with generated content (`.md`) and generated config (`.pages`).

This is accomplished by:

1. Defining an `on_files` in the plugin that synthesizes a `File` per config in the docs dir. This means we can later unconditionally pull from `Files` for both in-docs and generated configs.
2. Passing the `Files` down the chain to `NavigationMeta`
	- We can use the `Files` to validate the "out-of-docs" check, so we also remove the `docs_dir` arg
	- Additionally, generated files _aren't_ "in-docs", so that check would mean we did't add the generated docs. So removing it is vital to the overall change anyways
3. Making `_gather_metadata` operate on a "relative file" abstraction (e.g. the path below "docs_dir)
	- For `Page`s, that means adding `item.file.src_path` instead of `item.file.abs_src_path`
	- For sections, the metadata loading gets tricky. We have to load the _absolute_ path (because that's how the generated files work), but they path should be the _relative_ path so we match correctly later.
4. Replace `Meta.try_load_from` with `Meta.try_load_from_files` such that we always load from `Files`
	- But as mentioned, if we do successfully load, we need to swap the `path` attribute with the _relative path_

That summarizes the package changes, then there was a few test changes top facilitate this change:

- All the necessary refactoring to handle the swap from `docs_dir` to `files`
- `test_meta.py` changes for the correct `Files` lookup, and new method
- New test infrastructure to have a test define additional Mkdocs plugins, specifically so we can simulate `mkdocs-gen-files`
- New tests for the specific use-case of generated files


Fixes #78