### PR TITLE
fix filename in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,9 @@ If you wanted `introduction.md`, `page1.md` and `page2.md` to appear under their
 ```yaml
 nav:
     - Start:
+        - introduction.md
         - page1.md
         - page2.md
-        - summary.md
     - ...
 ```
 


### PR DESCRIPTION
in the descriptions above and below this snippet, the file `introduction.md` is used.
The `summary.md`  is simply a typo - `introduction.md` was meant.