### PR TITLE
Add ignore case for sorting

### DIFF
--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -180,7 +180,7 @@ class Meta:
             order = contents.get(Meta.ORDER_ATTRIBUTE)
             sort_type = contents.get(Meta.SORT_TYPE_ATTRIBUTE)
             order_by = contents.get(Meta.ORDER_BY_ATTRIBUTE)
-            
+
             if title is not None:
                 if not isinstance(title, str):
                     raise TypeError(

--- a/mkdocs_awesome_pages_plugin/meta.py
+++ b/mkdocs_awesome_pages_plugin/meta.py
@@ -108,6 +108,7 @@ class Meta:
     COLLAPSE_ATTRIBUTE = "collapse"
     COLLAPSE_SINGLE_PAGES_ATTRIBUTE = "collapse_single_pages"
     HIDE_ATTRIBUTE = "hide"
+    IGNORE_CASE_ATTRIBUTE = "ignore_case"
     ORDER_ATTRIBUTE = "order"
     SORT_TYPE_ATTRIBUTE = "sort_type"
     ORDER_BY_ATTRIBUTE = "order_by"
@@ -128,6 +129,7 @@ class Meta:
         collapse: bool = None,
         collapse_single_pages: bool = None,
         hide: bool = None,
+        ignore_case: bool = None,
         order: Optional[str] = None,
         sort_type: Optional[str] = None,
         order_by: Optional[str] = None,
@@ -143,6 +145,7 @@ class Meta:
         self.collapse = collapse
         self.collapse_single_pages = collapse_single_pages
         self.hide = hide
+        self.ignore_case = ignore_case
         self.order = order
         self.sort_type = sort_type
         self.order_by = order_by
@@ -173,10 +176,11 @@ class Meta:
             collapse = contents.get(Meta.COLLAPSE_ATTRIBUTE)
             collapse_single_pages = contents.get(Meta.COLLAPSE_SINGLE_PAGES_ATTRIBUTE)
             hide = contents.get(Meta.HIDE_ATTRIBUTE)
+            ignore_case = contents.get(Meta.IGNORE_CASE_ATTRIBUTE)
             order = contents.get(Meta.ORDER_ATTRIBUTE)
             sort_type = contents.get(Meta.SORT_TYPE_ATTRIBUTE)
             order_by = contents.get(Meta.ORDER_BY_ATTRIBUTE)
-
+            
             if title is not None:
                 if not isinstance(title, str):
                     raise TypeError(
@@ -241,6 +245,15 @@ class Meta:
                             context=path,
                         )
                     )
+            if ignore_case is not None:
+                if not isinstance(ignore_case, bool):
+                    raise TypeError(
+                        'Expected "{attribute}" attribute to be a boolean - got {type} [{context}]'.format(
+                            attribute=Meta.IGNORE_CASE_ATTRIBUTE,
+                            type=type(ignore_case),
+                            context=path,
+                        )
+                    )
             if order is not None:
                 if order != Meta.ORDER_ASC and order != Meta.ORDER_DESC:
                     raise TypeError(
@@ -278,6 +291,7 @@ class Meta:
                 collapse=collapse,
                 collapse_single_pages=collapse_single_pages,
                 hide=hide,
+                ignore_case=ignore_case,
                 order=order,
                 sort_type=sort_type,
                 order_by=order_by,

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -95,13 +95,20 @@ class AwesomeNavigation:
         if order is None and sort_type is None and order_by is None:
             return
 
+        ignore_case = meta.ignore_case or self.options.ignore_case
+
         if order_by == Meta.ORDER_BY_TITLE:
             key = lambda i: self._get_item_title(i)
         else:
             key = lambda i: basename(self._get_item_path(i))
 
         if sort_type == Meta.SORT_NATURAL:
-            key = natsort_keygen(key)
+            if ignore_case:
+                key = natsort_keygen(key, alg=ns.IGNORECASE)
+            else:
+                key = natsort_keygen(key)
+        elif ignore_case:
+            key = lambda i: key(i).casefold()
 
         items.sort(key=key, reverse=order == Meta.ORDER_DESC)
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -98,21 +98,16 @@ class AwesomeNavigation:
         ignore_case = meta.ignore_case or self.options.ignore_case
 
         if order_by == Meta.ORDER_BY_TITLE:
-            if ignore_case and sort_type != Meta.SORT_NATURAL:
-                key = lambda i: self._get_item_title(i).casefold()
-            else:
-                key = lambda i: self._get_item_title(i)
+            item_key = lambda i: self._get_item_title(i)
         else:
-            if ignore_case and sort_type != Meta.SORT_NATURAL:
-                key = lambda i: basename(self._get_item_path(i)).casefold()
-            else:
-                key = lambda i: basename(self._get_item_path(i))
+            item_key = lambda i: basename(self._get_item_path(i))
 
         if sort_type == Meta.SORT_NATURAL:
-            if ignore_case:
-                key = natsort_keygen(key, alg=ns.IGNORECASE)
-            else:
-                key = natsort_keygen(key)
+            key = natsort_keygen(item_key, alg=ns.IGNORECASE if ignore_case else ns.DEFAULT)
+        elif ignore_case:
+            key = lambda i: item_key(i).casefold()
+        else:
+            key = item_key
 
         items.sort(key=key, reverse=order == Meta.ORDER_DESC)
 

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -12,7 +12,7 @@ from mkdocs.structure.nav import (
     _add_previous_and_next_links,
 )
 from mkdocs.structure.pages import Page
-from natsort import natsort_keygen
+from natsort import natsort_keygen, ns
 
 from .meta import Meta, MetaNavItem, MetaNavRestItem, RestItemList
 from .options import Options

--- a/mkdocs_awesome_pages_plugin/navigation.py
+++ b/mkdocs_awesome_pages_plugin/navigation.py
@@ -98,17 +98,21 @@ class AwesomeNavigation:
         ignore_case = meta.ignore_case or self.options.ignore_case
 
         if order_by == Meta.ORDER_BY_TITLE:
-            key = lambda i: self._get_item_title(i)
+            if ignore_case and sort_type != Meta.SORT_NATURAL:
+                key = lambda i: self._get_item_title(i).casefold()
+            else:
+                key = lambda i: self._get_item_title(i)
         else:
-            key = lambda i: basename(self._get_item_path(i))
+            if ignore_case and sort_type != Meta.SORT_NATURAL:
+                key = lambda i: basename(self._get_item_path(i)).casefold()
+            else:
+                key = lambda i: basename(self._get_item_path(i))
 
         if sort_type == Meta.SORT_NATURAL:
             if ignore_case:
                 key = natsort_keygen(key, alg=ns.IGNORECASE)
             else:
                 key = natsort_keygen(key)
-        elif ignore_case:
-            key = lambda i: key(i).casefold()
 
         items.sort(key=key, reverse=order == Meta.ORDER_DESC)
 

--- a/mkdocs_awesome_pages_plugin/options.py
+++ b/mkdocs_awesome_pages_plugin/options.py
@@ -8,6 +8,7 @@ class Options:
         order: str = None,
         sort_type: str = None,
         order_by: str = None,
+        ignore_case: bool = None,
     ):
         self.filename = filename
         self.collapse_single_pages = collapse_single_pages
@@ -15,3 +16,4 @@ class Options:
         self.order = order
         self.sort_type = sort_type
         self.order_by = order_by
+        self.ignore_case = ignore_case

--- a/mkdocs_awesome_pages_plugin/tests/navigation/test_order_and_sort.py
+++ b/mkdocs_awesome_pages_plugin/tests/navigation/test_order_and_sort.py
@@ -289,3 +289,91 @@ class TestOrderAndSort(NavigationTestCase):
             [self.page("30"), self.page("1000"), self.page("200"), self.page("4")],
         )
         self.assertValidNavigation(navigation.to_mkdocs())
+
+    def test_section_asc_ignore_case(self):
+        navigation = self.createAwesomeNavigation(
+            [
+                self.page("B"),
+                self.page("a"),
+                self.page("C"),
+                Meta(ignore_case=True, order=Meta.ORDER_ASC),
+            ]
+        )
+
+        self.assertNavigationEqual(
+            navigation.items,
+            [
+                self.page("a"),
+                self.page("B"),
+                self.page("C"),
+            ],
+        )
+        self.assertValidNavigation(navigation.to_mkdocs())
+
+    def test_section_asc_natural_ignore_case(self):
+        navigation = self.createAwesomeNavigation(
+            [
+                self.page("B"),
+                self.page("a"),
+                self.page("C"),
+                Meta(
+                    ignore_case=True,
+                    order=Meta.ORDER_ASC,
+                    sort_type=Meta.SORT_NATURAL,
+                ),
+            ]
+        )
+
+        self.assertNavigationEqual(
+            navigation.items,
+            [
+                self.page("a"),
+                self.page("B"),
+                self.page("C"),
+            ],
+        )
+        self.assertValidNavigation(navigation.to_mkdocs())
+
+    def test_section_desc_ignore_case(self):
+        navigation = self.createAwesomeNavigation(
+            [
+                self.page("B"),
+                self.page("a"),
+                self.page("C"),
+                Meta(ignore_case=True, order=Meta.ORDER_DESC),
+            ]
+        )
+
+        self.assertNavigationEqual(
+            navigation.items,
+            [
+                self.page("C"),
+                self.page("B"),
+                self.page("a"),
+            ],
+        )
+        self.assertValidNavigation(navigation.to_mkdocs())
+
+    def test_section_desc_natural_ignore_case(self):
+        navigation = self.createAwesomeNavigation(
+            [
+                self.page("B"),
+                self.page("a"),
+                self.page("C"),
+                Meta(
+                    ignore_case=True,
+                    order=Meta.ORDER_DESC,
+                    sort_type=Meta.SORT_NATURAL,
+                ),
+            ]
+        )
+
+        self.assertNavigationEqual(
+            navigation.items,
+            [
+                self.page("C"),
+                self.page("B"),
+                self.page("a"),
+            ],
+        )
+        self.assertValidNavigation(navigation.to_mkdocs())


### PR DESCRIPTION
Added option to ignore case for sorting pages.

Similar to previous PR, but added `ignore_case` as an option in the `Meta` and `Option` classes.  Furthermore, modified the `_order` method so that `ignore_case` should work for natural and standard sorting. 